### PR TITLE
Use user AD credentials for guac connection

### DIFF
--- a/src/apps/apps.go
+++ b/src/apps/apps.go
@@ -172,15 +172,23 @@ func createConnections() error {
 					},
 					GuacamoleXMLParam{
 						ParamName:  "username",
-						ParamValue: fmt.Sprintf("%s@%s", user.Sam, conf.WindowsDomain),
+						ParamValue: user.Sam,
 					},
 					GuacamoleXMLParam{
 						ParamName:  "password",
-						ParamValue: conf.Password,
+						ParamValue: user.WindowsPassword,
 					},
 					GuacamoleXMLParam{
 						ParamName:  "remote-app",
 						ParamValue: fmt.Sprintf("||%s", application.Alias),
+					},
+					GuacamoleXMLParam{
+						ParamName:  "security",
+						ParamValue: "nla",
+					},
+					GuacamoleXMLParam{
+						ParamName:  "ignore-cert",
+						ParamValue: "true",
 					},
 				},
 			})


### PR DESCRIPTION
now uses the windows password for users instead of admin password + ignore certificate and nla security