### PR TITLE
a new error was created in a loop instead of using an existing one

### DIFF
--- a/src/apps/main.go
+++ b/src/apps/main.go
@@ -93,7 +93,7 @@ func main() {
 	module.Get("/apps/me", listApplicationsForSamAccount)
 	err := errors.New("")
 	for err != nil {
-		err := createConnections()
+		err = createConnections()
 		module.Log.Error(err)
 		time.Sleep(time.Second * 3)
 	}


### PR DESCRIPTION
An infinite loop was created by unintentionally creating an new error within a loop.